### PR TITLE
OLH-874: Give the AM API stub a domain

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -212,6 +212,35 @@ Resources:
       RetentionInDays: 30
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
+  AccountManagementStubCustomDomain:
+    Type: AWS::ApiGatewayV2::DomainName
+    Properties:
+      DomainName: !Sub am-stub.home.${Environment}.account.gov.uk
+      DomainNameConfigurations:
+        - CertificateArn: !Sub "{{resolve:ssm:/${Environment}/Platform/ACM/HostedZone/Certificate/Home/ARN}}"
+          EndpointType: REGIONAL
+          SecurityPolicy: TLS_1_2
+
+  AccountManagementStubDnsRecord:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      Name: !Sub am-stub.home.${Environment}.account.gov.uk
+      Type: A
+      HostedZoneId: !Sub "{{resolve:ssm:/${Environment}/Platform/Route53/HostedZone/Home}}"
+      AliasTarget:
+        DNSName: !GetAtt AccountManagementStubCustomDomain.RegionalDomainName
+        HostedZoneId: !GetAtt AccountManagementStubCustomDomain.RegionalHostedZoneId
+        EvaluateTargetHealth: true
+
+  ApiGatewayMapping:
+    Type: AWS::ApiGatewayV2::ApiMapping
+    Properties:
+      DomainName: !Sub am-stub.home.${Environment}.account.gov.uk
+      ApiId: !Ref AccountManagementStubApi
+      Stage: "$default"
+    DependsOn:
+      - AccountManagementStubCustomDomain
+
   AccountManagementStubApiEndpoint:
     Type: AWS::SSM::Parameter
     Properties:

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -247,7 +247,7 @@ Resources:
       Description: The API Gateway endpoint for the Account Management stub
       Name: !Sub "/${AWS::StackName}/Stub/AccountManagement/Endpoint"
       Type: String
-      Value: !GetAtt AccountManagementStubApi.ApiEndpoint
+      Value: !Sub am-stub.home.${Environment}.account.gov.uk
 
   ######################################
   # OIDC Authorization API Stub


### PR DESCRIPTION
## What
Give the account management API stub a domain in our dev and build environments so the frontend can reach it.

This is following the same pattern as we used for the domain at the frontend (see https://github.com/alphagov/di-account-management-frontend/blob/main/deploy/template.yaml#L736-L770).

## Why

The firewall rules on the frontend app stop it from making requests to any non-`*.gov.uk` domains. This means requests to the stub API were timing out and I was seeing 504 errors when testing the frontend.

## Testing

I've deployed the following stack to dev as `alex-stub-domain-test` which sets up a domain for the stub in dev:

```yaml
AWSTemplateFormatVersion: "2010-09-09"
Transform: AWS::Serverless-2016-10-31
Description: "A test stack to add a domain to API Gateway."

Parameters:
  Environment:
    Description: "The environment type"
    Type: "String"
    AllowedValues:
      - "dev"
      - "build"
    ConstraintDescription: must be dev or build
  ApiGatewayID:
    Description: >
      The ID for the API Gateway to point the domain at
    Type: String
    Default: lgutxhwiu9

Resources:
  CustomDomain:
    Type: AWS::ApiGatewayV2::DomainName
    Properties:
      DomainName: !Sub am-stub.home.${Environment}.account.gov.uk
      DomainNameConfigurations:
        - CertificateArn: !Sub "{{resolve:ssm:/${Environment}/Platform/ACM/HostedZone/Certificate/Home/ARN}}"
          EndpointType: REGIONAL
          SecurityPolicy: TLS_1_2

  DnsRecord:
    Type: AWS::Route53::RecordSet
    Properties:
      Name: !Sub am-stub.home.${Environment}.account.gov.uk
      Type: A
      HostedZoneId: !Sub "{{resolve:ssm:/${Environment}/Platform/Route53/HostedZone/Home}}"
      AliasTarget:
        DNSName: !GetAtt CustomDomain.RegionalDomainName
        HostedZoneId: !GetAtt CustomDomain.RegionalHostedZoneId
        EvaluateTargetHealth: true

  ApiGatewayMapping:
    Type: AWS::ApiGatewayV2::ApiMapping
    Properties:
      DomainName: !Sub am-stub.home.${Environment}.account.gov.uk
      ApiId: !Ref ApiGatewayID
      Stage: "$default"
    DependsOn:
      - CustomDomain

```

This has deployed OK and you can send requests to the stub via the domain: 

```bash
$ curl -i https://am-stub.home.dev.account.gov.uk/delete-account
HTTP/2 204
date: Mon, 17 Jul 2023 14:33:09 GMT
apigw-requestid: INmdziORrPEEJWA=
```
## Other considerations

I'll need to delete this test stack before merging the PR otherwise the deploy will fail because they're both trying to use the same domain name in dev.