### PR TITLE
OLH-874: Skip DLQ Checkov checks

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -69,7 +69,6 @@ Globals:
       - !Ref AWS::NoValue
 
 Resources:
-
   ######################################
   # Encryption
   ######################################
@@ -132,6 +131,7 @@ Resources:
   ######################################
   AccountManagementStubFunction:
     Type: AWS::Serverless::Function
+    # checkov:skip=CKV_AWS_116
     DependsOn:
       - AccountManagementStubFunctionLogGroup
     Properties:
@@ -255,6 +255,7 @@ Resources:
   ######################################
   OidcAuthorizeApiStubFunction:
     Type: AWS::Serverless::Function
+    # checkov:skip=CKV_AWS_116
     DependsOn:
       - OidcAuthorizeApiStubFunctionLogGroup
     Properties:
@@ -271,8 +272,10 @@ Resources:
       Timeout: 5
       Environment:
         Variables:
-          DUMMY_TXMA_QUEUE_URL: !FindInMap [TxmaDummyInputQueue, !Ref Environment, QueueUrl]
-          ACCOUNT_MANAGEMENT_URL: !FindInMap [AccountManagementUI, !Ref Environment, url]
+          DUMMY_TXMA_QUEUE_URL:
+            !FindInMap [TxmaDummyInputQueue, !Ref Environment, QueueUrl]
+          ACCOUNT_MANAGEMENT_URL:
+            !FindInMap [AccountManagementUI, !Ref Environment, url]
       VpcConfig:
         SubnetIds:
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
@@ -358,7 +361,8 @@ Resources:
           - Effect: Allow
             Action:
               - sqs:SendMessage
-            Resource: !FindInMap [TxmaDummyInputQueue, !Ref Environment, QueueArn]
+            Resource:
+              !FindInMap [TxmaDummyInputQueue, !Ref Environment, QueueArn]
           - Effect: Allow
             Action:
               - kms:Decrypt
@@ -371,6 +375,7 @@ Resources:
   ######################################
   OidcUserInfoApiStubFunction:
     Type: AWS::Serverless::Function
+    # checkov:skip=CKV_AWS_116
     DependsOn:
       - OidcUserInfoApiStubFunctionLogGroup
     Properties:
@@ -447,9 +452,9 @@ Resources:
       Description: HTTP API to emulate a token issuer for authorization in non-prod environments
       StageName: !Ref Environment
       CacheClusterEnabled: true
-      CacheClusterSize: '0.5'
+      CacheClusterSize: "0.5"
       MethodSettings:
-        - HttpMethod: '*'
+        - HttpMethod: "*"
           CachingEnabled: true
           ResourcePath: /*
       TracingEnabled: true


### PR DESCRIPTION
These lambdas are for our stub functions and we don't care about saving requests if anything goes wrong.

Currently the pipeline is refusing to deploy this stack because this rule is failing, so skip it for the stub lambdas.

We do have the pipeline [set to `CONTINUE` on a Checkov failure](https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3138355242/SAM+deploy+pipeline+parameters+table), but that doesn't seem to be working at the moment. It might take the dev platform team a few days to figure that out so let's skip the rules for now to keep our work unblocked.