### PR TITLE
OLH-875: Wait for SQS message to be sent

### DIFF
--- a/oidc/authorize/oidc-authorize-stub.ts
+++ b/oidc/authorize/oidc-authorize-stub.ts
@@ -98,7 +98,7 @@ export const handler = async (
   try {
     await writeNonce(code, nonce);
 
-    sendSqsMessage(JSON.stringify(newTxmaEvent()), DUMMY_TXMA_QUEUE_URL);
+    await sendSqsMessage(JSON.stringify(newTxmaEvent()), DUMMY_TXMA_QUEUE_URL);
     return {
       statusCode: 302,
       headers: {


### PR DESCRIPTION
This lambda wasn't sending the message to SQS before returning which meant the stub wasn't triggering the backend. `sendSqSMessage` is an async function so we need to `await` it to make sure it's finished before carrying on.

I've deployed this change to dev and seen in the [SQS / lambda logs](https://eu-west-2.console.aws.amazon.com/lambda/home?region=eu-west-2#/functions/dev-account-mgmt-backend-save-raw-events?tab=monitoring) that the backend is now running when I log into the frontend.