### PR TITLE
BAU: Add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,43 @@
+## Proposed changes
+
+<!-- Provide a summary of your changes in the title above -->
+<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->
+
+### What changed
+
+<!-- Describe the changes in detail - the "what"-->
+
+### Why did it change
+
+<!-- Describe the reason these changes were made - the "why" -->
+
+### Related links
+
+<!-- List any related PRs -->
+<!-- List any related ADRs or RFCs -->
+
+## Checklists
+
+<!-- Merging this PR deploys the stubs. Please answer accurately. -->
+
+### Environment variables or secrets
+
+- [ ] No environment variables or secrets were added or changed
+
+<!-- Delete if changes DO NOT include new environment variables or secrets -->
+
+- [ ] Added parameters to Cloudformation template
+- [ ] Added new secret or systems manager parameter
+- [ ] Added new environment variable
+
+### Permissions
+
+- [ ] This PR adds or changes permissions
+
+## Testing
+
+<!-- Provide a summary of any manual testing you've done, for example deploying the branch to dev -->
+
+## How to review
+
+<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->


### PR DESCRIPTION
Template taken from
https://github.com/alphagov/di-account-management-backend/pull/130 since this repository is most like the backend one.

I'm hoping that we get more consistent in our pull request descriptions if we have similar templates on all our repositories