### PR TITLE
OLH-1027: Use a real page for logout

### DIFF
--- a/oidc/configuration/oidc-config-stub.ts
+++ b/oidc/configuration/oidc-config-stub.ts
@@ -32,7 +32,7 @@ export const handler = async () => {
     trustmarks: "https://unsuported-by-stub.gov.uk/",
     subject_types_supported: ["public", "pairwise"],
     userinfo_endpoint: `https://oidc-stub.home.${ENVIRONMENT}.account.gov.uk/userinfo`,
-    end_session_endpoint: "https://unsuported-by-stub.gov.uk/",
+    end_session_endpoint: "https://signin.build.account.gov.uk/signed-out",
     id_token_signing_alg_values_supported: ["ES256", "RS256"],
     claim_types_supported: ["normal"],
     claims_supported: [


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed

Use a real URL for the end session field in the OIDC configuration.

### Why did it change

Currently when a user clicks the 'Sign out' button using the stub they end up on an error page because the OIDC end session endpoint in our configuration file doesn't exist.

Rather than writing a new lambda as part of this stub API, send the user directly to the Auth team's frontend to see the sign out page. This intentionally uses the build environment as there isn't an equivalent for dev.

This link goes straight to the user-facing page and doesn't hit the actual build OIDC end session URL. This is intentional as our user doesn't have a session with the real OIDC server and I didn't want to run the risk of seeing any errors or getting our browser cookies in an odd state. It does mean there's a bunch of URL parameters present that the user wouldn't usually see, but that's fine for the stub.

### Related links

<!-- List any related PRs -->
<!-- List any related ADRs or RFCs -->

## Checklists

<!-- Merging this PR deploys the stubs. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed


### Permissions

- [ ] This PR adds or changes permissions

## Testing

I've deployed this to dev, checked the new value is present in the configuration and that the sign out link goes to the new place. If you want to test yourself, be aware that the frontend app caches the OIDC configuration so you may need to force a re-deploy on the frontend (by using the Github action) to pick up the new value.

You can also run the frontend locally and set `API_BASE_URL=https://oidc-stub.home.dev.account.gov.uk` in `.env` and check the sign out there. 

## How to review

<!-- Describe any non-standard steps to review this work, or higlight any areas that you'd like the reviewer's opinion on -->
