### PR TITLE
OLH-1026: Fix phone_number claim name

### DIFF
--- a/oidc/userinfo/models.ts
+++ b/oidc/userinfo/models.ts
@@ -2,7 +2,7 @@ export interface UserInfo {
   sub: string;
   email: string;
   email_verified: boolean;
-  phone: string;
-  phone_verified: boolean;
+  phone_number: string;
+  phone_number_verified: boolean;
   updated_at: string;
 }

--- a/oidc/userinfo/oidc-userinfo-stub.ts
+++ b/oidc/userinfo/oidc-userinfo-stub.ts
@@ -10,8 +10,8 @@ const newUserInfo = (): UserInfo => ({
   sub: uuid(),
   email: "test@test.com",
   email_verified: true,
-  phone: "1234567890",
-  phone_verified: true,
+  phone_number: "1234567890",
+  phone_number_verified: true,
   updated_at: Date.now().toString(),
 });
 


### PR DESCRIPTION
## Proposed changes

<!-- Provide a summary of your changes in the title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[OLH-XXXX]: PR Title` -->

### What changed

Update the phone number claim name to match what the frontend is expecting.

### Why did it change

The frontend is currently not storing the user's phone number in the session once it's made the request to the `/userinfo` endpoint.

This means we're not displaying the 'change your phone number' flow and the frontend is behaving as if the user has an authenticator app.

Our [public documentation][1] says that the phone number claim is called `phone`, however the [OIDC specification][2] says it should be `phone_number`.

This is a mistake in our documentation and the frontend is expecting `phone_number`.

### Related links

[Our public documentation][1]
[OIDC specification][2] 

## Checklists

<!-- Merging this PR deploys the stubs. Please answer accurately. -->

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Permissions

- [ ] This PR adds or changes permissions

## Testing

I've deployed this branch to dev and pointed my local frontend at the branch. You can see the phone number field now:

<img width="652" alt="image" src="https://github.com/alphagov/di-account-management-stubs/assets/6362602/0a4460c3-c6d7-4300-9152-6e82d2ac76aa">


## How to review

<!-- Describe any non-standard steps to review this work, or highlight any areas that you'd like the reviewer's opinion on -->

[1]: https://docs.sign-in.service.gov.uk/integrate-with-integration-environment/integrate-with-code-flow/#retrieve-user-information
[2]: https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims